### PR TITLE
Fix circular import for `ProteinRecord`

### DIFF
--- a/pyeed/core/abstractannotation.py
+++ b/pyeed/core/abstractannotation.py
@@ -51,7 +51,7 @@ class AbstractAnnotation(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/abstractannotation.py
+++ b/pyeed/core/abstractannotation.py
@@ -51,7 +51,7 @@ class AbstractAnnotation(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/abstractannotation.py
+++ b/pyeed/core/abstractannotation.py
@@ -51,7 +51,7 @@ class AbstractAnnotation(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/alignmentdata.py
+++ b/pyeed/core/alignmentdata.py
@@ -51,7 +51,7 @@ class AlignmentData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/alignmentdata.py
+++ b/pyeed/core/alignmentdata.py
@@ -51,7 +51,7 @@ class AlignmentData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/alignmentdata.py
+++ b/pyeed/core/alignmentdata.py
@@ -51,7 +51,7 @@ class AlignmentData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/blastdata.py
+++ b/pyeed/core/blastdata.py
@@ -90,7 +90,7 @@ class BlastData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/blastdata.py
+++ b/pyeed/core/blastdata.py
@@ -90,7 +90,7 @@ class BlastData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/blastdata.py
+++ b/pyeed/core/blastdata.py
@@ -90,7 +90,7 @@ class BlastData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/clustalomegadata.py
+++ b/pyeed/core/clustalomegadata.py
@@ -32,7 +32,7 @@ class ClustalOmegaData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/clustalomegadata.py
+++ b/pyeed/core/clustalomegadata.py
@@ -32,7 +32,7 @@ class ClustalOmegaData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/clustalomegadata.py
+++ b/pyeed/core/clustalomegadata.py
@@ -32,7 +32,7 @@ class ClustalOmegaData(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/cluster.py
+++ b/pyeed/core/cluster.py
@@ -49,7 +49,7 @@ class Cluster(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/cluster.py
+++ b/pyeed/core/cluster.py
@@ -49,7 +49,7 @@ class Cluster(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/cluster.py
+++ b/pyeed/core/cluster.py
@@ -49,7 +49,7 @@ class Cluster(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/dnarecord.py
+++ b/pyeed/core/dnarecord.py
@@ -62,7 +62,7 @@ class DNARecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/dnarecord.py
+++ b/pyeed/core/dnarecord.py
@@ -62,7 +62,7 @@ class DNARecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/dnarecord.py
+++ b/pyeed/core/dnarecord.py
@@ -62,7 +62,7 @@ class DNARecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/organism.py
+++ b/pyeed/core/organism.py
@@ -108,7 +108,7 @@ class Organism(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/organism.py
+++ b/pyeed/core/organism.py
@@ -108,7 +108,7 @@ class Organism(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/organism.py
+++ b/pyeed/core/organism.py
@@ -108,7 +108,7 @@ class Organism(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/pairwisealignment.py
+++ b/pyeed/core/pairwisealignment.py
@@ -60,7 +60,7 @@ class PairwiseAlignment(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/pairwisealignment.py
+++ b/pyeed/core/pairwisealignment.py
@@ -60,7 +60,7 @@ class PairwiseAlignment(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/pairwisealignment.py
+++ b/pyeed/core/pairwisealignment.py
@@ -60,7 +60,7 @@ class PairwiseAlignment(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/proteinrecord.py
+++ b/pyeed/core/proteinrecord.py
@@ -103,7 +103,7 @@ class ProteinRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/proteinrecord.py
+++ b/pyeed/core/proteinrecord.py
@@ -16,6 +16,8 @@ from sdRDM.base.listplus import ListPlus
 from sdRDM.tools.utils import elem2dict
 
 from pyeed.container.abstract_container import Blastp
+from pyeed.fetch.blast import BlastProgram, NCBIDataBase
+from pyeed.fetch.proteinfetcher import ProteinFetcher
 
 from .dnarecord import DNARecord
 from .region import Region
@@ -101,7 +103,7 @@ class ProteinRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/proteinrecord.py
+++ b/pyeed/core/proteinrecord.py
@@ -103,7 +103,7 @@ class ProteinRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/proteinrecord.py
+++ b/pyeed/core/proteinrecord.py
@@ -16,7 +16,6 @@ from sdRDM.base.listplus import ListPlus
 from sdRDM.tools.utils import elem2dict
 
 from pyeed.container.abstract_container import Blastp
-from pyeed.fetch.proteinfetcher import ProteinFetcher
 
 from .dnarecord import DNARecord
 from .region import Region

--- a/pyeed/core/region.py
+++ b/pyeed/core/region.py
@@ -38,7 +38,7 @@ class Region(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/region.py
+++ b/pyeed/core/region.py
@@ -38,7 +38,7 @@ class Region(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/region.py
+++ b/pyeed/core/region.py
@@ -38,7 +38,7 @@ class Region(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/sequence.py
+++ b/pyeed/core/sequence.py
@@ -38,7 +38,7 @@ class Sequence(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/sequence.py
+++ b/pyeed/core/sequence.py
@@ -38,7 +38,7 @@ class Sequence(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/sequence.py
+++ b/pyeed/core/sequence.py
@@ -38,7 +38,7 @@ class Sequence(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/sequencerecord.py
+++ b/pyeed/core/sequencerecord.py
@@ -62,7 +62,7 @@ class SequenceRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _object_terms: Set[str] = PrivateAttr(default={"http://edamontology.org/data_0849"})

--- a/pyeed/core/sequencerecord.py
+++ b/pyeed/core/sequencerecord.py
@@ -62,7 +62,7 @@ class SequenceRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _object_terms: Set[str] = PrivateAttr(default={"http://edamontology.org/data_0849"})

--- a/pyeed/core/sequencerecord.py
+++ b/pyeed/core/sequencerecord.py
@@ -62,7 +62,7 @@ class SequenceRecord(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _object_terms: Set[str] = PrivateAttr(default={"http://edamontology.org/data_0849"})

--- a/pyeed/core/site.py
+++ b/pyeed/core/site.py
@@ -35,7 +35,7 @@ class Site(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/site.py
+++ b/pyeed/core/site.py
@@ -35,7 +35,7 @@ class Site(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/site.py
+++ b/pyeed/core/site.py
@@ -35,7 +35,7 @@ class Site(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/standardnumbering.py
+++ b/pyeed/core/standardnumbering.py
@@ -47,7 +47,7 @@ class StandardNumbering(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="29cf09884547d4761a0fc9070d62063a996a585d"
+        default="d74df50f2e1144d97bc505140af6f320acba7e80"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/standardnumbering.py
+++ b/pyeed/core/standardnumbering.py
@@ -47,7 +47,7 @@ class StandardNumbering(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="9150089ef67185febda4ddf3618197b880576fd9"
+        default="935e9b5cb924657615539e6d4813287fea72ff35"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/core/standardnumbering.py
+++ b/pyeed/core/standardnumbering.py
@@ -47,7 +47,7 @@ class StandardNumbering(
 
     _repo: Optional[str] = PrivateAttr(default="https://github.com/PyEED/pyeed")
     _commit: Optional[str] = PrivateAttr(
-        default="d74df50f2e1144d97bc505140af6f320acba7e80"
+        default="9150089ef67185febda4ddf3618197b880576fd9"
     )
 
     _raw_xml_data: Dict = PrivateAttr(default_factory=dict)

--- a/pyeed/fetch/ncbiproteinmapper.py
+++ b/pyeed/fetch/ncbiproteinmapper.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import io
 import logging
 import re
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from Bio import SeqFeature, SeqIO
 from Bio.SeqRecord import SeqRecord
@@ -10,7 +12,9 @@ from pyeed.core.organism import Organism
 from pyeed.core.region import Region
 from pyeed.core.dnarecord import DNARecord
 from pyeed.core.annotation import Annotation
-from pyeed.core.proteinrecord import ProteinRecord
+
+if TYPE_CHECKING:
+    from pyeed.core.proteinrecord import ProteinRecord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +38,8 @@ class NCBIProteinMapper:
         """
         Maps the fetched data to an instance of the `ProteinInfo` class.
         """
+
+        from pyeed.core.proteinrecord import ProteinRecord
 
         seq_records = self._to_seq_records(responses)
 
@@ -246,8 +252,8 @@ class NCBIProteinMapper:
 
             region = Region(
                 id=reference_ids[0],
-                start = int(start),
-                end = int(end),
+                start=int(start),
+                end=int(end),
                 type=Annotation.CODING_SEQ,
             )
             regions.append(region)

--- a/pyeed/fetch/uniprotmapper.py
+++ b/pyeed/fetch/uniprotmapper.py
@@ -1,8 +1,16 @@
+from __future__ import annotations
+
 import logging
 import re
 
-from pyeed.core import Organism, ProteinRecord, Annotation
+from typing import List, TYPE_CHECKING
+
+from pyeed.core import Organism, Annotation
 from pyeed.core.ontology import Ontology
+
+
+if TYPE_CHECKING:
+    from pyeed.core import ProteinRecord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -13,13 +21,17 @@ class UniprotMapper:
 
     def map_uniprot_data(self, uniprot_data: dict) -> ProteinRecord:
 
+        from pyeed.core import ProteinRecord
+
         # Organism information
         organism = Organism(
             taxonomy_id=uniprot_data["organism"]["taxonomy"],
         )
 
         try:
-            ec_number = uniprot_data["protein"]["recommendedName"]["ecNumber"][0]["value"]
+            ec_number = uniprot_data["protein"]["recommendedName"]["ecNumber"][0][
+                "value"
+            ]
         except KeyError:
             ec_number = None
 
@@ -47,6 +59,8 @@ class UniprotMapper:
     ) -> ProteinRecord:
         """Maps the sequence information from Uniprot and annotations from InterPro
         records to a ProteinInfo object."""
+
+        from pyeed.core import ProteinRecord
 
         assert (
             interpro["results"][0]["proteins"][0]["accession"].upper()
@@ -88,8 +102,14 @@ class UniprotMapper:
 
         return protein_info
 
-    def map_interpro(self, interpro: dict, protein_info: ProteinRecord) -> ProteinRecord:
+    def map_interpro(
+        self, interpro: dict, protein_info: ProteinRecord
+    ) -> ProteinRecord:
         """Maps the InterPro records to a ProteinInfo object."""
+
+        raise NotImplementedError(
+            f"This method uses the old schema and does not support ProteinRegionType"
+        )
 
         interpro_pattern = re.compile(r"IPR\d{6}")
         # pfam_pattern = re.compile(r"PF\d{5}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ tqdm = "^4.66.1"
 sdrdm-database = { extras = [
     "postgres",
 ], git = "https://github.com/JR-1991/sdrdm-database.git", branch = "iterative-linking-tables" }
-psycopg2 = "^2.9.9"
+psycopg2-binary = "^2.9.9"
 networkx = "^3.2.1"
 plotly = "^5.18.0"
 nbformat = "^5.9.2"

--- a/tests/integration/test_circular.py
+++ b/tests/integration/test_circular.py
@@ -1,0 +1,8 @@
+class TestCircular:
+    def test_circular(self):
+        """This test makes sure that there are no circular imports"""
+
+        try:
+            from pyeed import core
+        except ImportError as e:
+            assert False, f"Circular import detected:\n\n{e.msg}"


### PR DESCRIPTION
There was a circular import die to the family of `XYZMapper` classes that import `ProteinRecord`. Due to the sdRDM action pulling imports from all-over the code to the top, the circular dependency cannot be resolved by leaving the import within the method in `ProteinRecord`.

This PR inverts the problem and pulls the `ProteinRecord` into the `XYZMapper` class methods. For type annotations that are using `ProteinRecord` the `TYPE_CHECKING` pattern has been employed to preserve type checking while not inducing circular imports. I have also added a test to check circular dependencies.

I would advise you to pull out any higher logic from the `core` module to prevent this from happening.